### PR TITLE
ensure filename is lower case

### DIFF
--- a/scripts/page/generate-page.js
+++ b/scripts/page/generate-page.js
@@ -6,7 +6,7 @@ const createPageTemplate = require("./page-template");
 
 function generatePage(dir, args) {
   const handle = args[3];
-  const page = `${dir}/${handle}.js`;
+  const page = `${dir}/${handle.toLowerCase()}.js`;
   if (fs.existsSync(page)) {
     console.log(`${page} already exists`);
   } else {


### PR DESCRIPTION
When I was testing Tyler's branch I noticed if the user passed a cased name it would create a file with that way, which is annoying for routes. 