### PR TITLE
add user-agent

### DIFF
--- a/server/handlers/client.cli.js
+++ b/server/handlers/client.cli.js
@@ -1,0 +1,17 @@
+import ApolloClient from "apollo-boost";
+
+export const createClient = (shop, accessToken) => {
+  return new ApolloClient({
+    uri: `https://${shop}/admin/api/2019-07/graphql.json`,
+    request: operation => {
+      operation.setContext({
+        headers: {
+          "X-Shopify-Access-Token": accessToken,
+          "User-Agent": `shopify-app-node ${
+            process.env.npm_package_version
+          } | Shopify App CLI`
+        }
+      });
+    }
+  });
+};

--- a/server/handlers/client.js
+++ b/server/handlers/client.js
@@ -6,7 +6,8 @@ export const createClient = (shop, accessToken) => {
     request: operation => {
       operation.setContext({
         headers: {
-          "X-Shopify-Access-Token": accessToken
+          "X-Shopify-Access-Token": accessToken,
+          "User-Agent": `shopify-app-node ${process.env.npm_package_version}`
         }
       });
     }


### PR DESCRIPTION
As per @nwtn this seems like the best way to get the `npm package version` for the user agent. 