### PR TITLE
Fix - forceRedirect only works if shop is in query parameters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7976,6 +7976,11 @@
         }
       }
     },
+    "js-cookie": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.0.tgz",
+      "integrity": "sha1-Gywnmm7s44ChIWi5JIUmWzWx7/s="
+    },
     "js-levenshtein": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "dotenv": "^7.0.0",
     "graphql": "^14.2.1",
     "isomorphic-fetch": "^2.1.1",
+    "js-cookie": "^2.2.0",
     "koa": "^2.7.0",
     "koa-router": "^7.4.0",
     "koa-session": "^5.10.1",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -3,6 +3,7 @@ import { ApolloProvider } from "react-apollo";
 import App, { Container } from "next/app";
 import { AppProvider } from "@shopify/polaris";
 import { Provider } from "@shopify/app-bridge-react";
+import Cookies from "js-cookie";
 import "@shopify/polaris/styles.css";
 
 const client = new ApolloClient({
@@ -11,12 +12,9 @@ const client = new ApolloClient({
   }
 });
 class MyApp extends App {
-  static async getInitialProps(server) {
-    const shopOrigin = server.ctx.query.shop;
-    return { shopOrigin };
-  }
   render() {
-    const { Component, pageProps, shopOrigin } = this.props;
+    const { Component, pageProps } = this.props;
+    const shopOrigin = Cookies.get("shopOrigin");
     return (
       <Container>
         <AppProvider>

--- a/server/server.js
+++ b/server/server.js
@@ -32,6 +32,7 @@ app.prepare().then(() => {
         //Auth token and shop available in session
         //Redirect to shop upon auth
         const { shop, accessToken } = ctx.session;
+        ctx.cookies.set("shopOrigin", shop, { httpOnly: false });
         ctx.redirect("/");
       }
     })


### PR DESCRIPTION
afterAuth forces redirect to '/' which causes errors if the page is loaded outside of Shopify Admin.
MyApp is expecting shop to be available as a query parameter and thus causes an exception on the front end once the app is installed.

In order to fix this I set the shop as a cookie which is accessed by MyApp