### PR TITLE
Add Contextual Save Bar

### DIFF
--- a/components/ContextualSaveBar.js
+++ b/components/ContextualSaveBar.js
@@ -1,0 +1,51 @@
+import { useContext, useEffect, useState } from "react";
+import { Context as ShopifyContext } from "@shopify/app-bridge-react";
+import { ContextualSaveBar as SaveBar } from "@shopify/app-bridge/actions";
+
+function useContextualSaveBar(save, discard) {
+  const [shouldSave, setShouldSave] = useState(false);
+  const [shouldDiscard, setShouldDiscard] = useState(false);
+
+  useEffect(() => {
+    if (shouldSave) {
+      save[0]();
+      setShouldSave(false);
+    }
+  }, [shouldSave, ...save]);
+
+  useEffect(() => {
+    if (shouldDiscard) {
+      discard[0]();
+      setShouldDiscard(false);
+    }
+  }, [shouldDiscard, ...discard]);
+
+  return [() => setShouldSave(true), () => setShouldDiscard(true)];
+}
+
+const ContextualSaveBar = ({ isShown, save, discard, options }) => {
+  const app = useContext(ShopifyContext);
+  const [saveBar] = useState(SaveBar.create(app, options));
+  const [onSave, onDiscard] = useContextualSaveBar(save, discard);
+
+  useEffect(() => {
+    const saveUnsub = saveBar.subscribe(SaveBar.Action.SAVE, onSave);
+
+    const discardUnsub = saveBar.subscribe(SaveBar.Action.DISCARD, onDiscard);
+
+    return () => {
+      saveUnsub();
+      discardUnsub();
+    };
+  }, []);
+
+  if (isShown) {
+    saveBar.dispatch(SaveBar.Action.SHOW);
+  } else {
+    saveBar.dispatch(SaveBar.Action.HIDE);
+  }
+
+  return null;
+};
+
+export default ContextualSaveBar;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5331,9 +5331,9 @@
       }
     },
     "@shopify/app-bridge": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@shopify/app-bridge/-/app-bridge-1.14.0.tgz",
-      "integrity": "sha512-l0k/AGlnxbI7AmBv97FNcz6Fx6KCQ7eL7F8WTYyx6V7MVtTehszzln/Fez9Up6NF91HCLulYgvj3NT8AaXetCA=="
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@shopify/app-bridge/-/app-bridge-1.15.0.tgz",
+      "integrity": "sha512-AKp55HclDyuA3rq561qGo7L3oFzW88eno8U5Lliod4KfJnEoiBFZqWK28unOsk5c01bl3b5bOdhEl4wSa88C7A=="
     },
     "@shopify/app-bridge-react": {
       "version": "1.14.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@babel/polyfill": "^7.6.0",
     "@babel/preset-env": "^7.6.2",
     "@babel/register": "^7.6.2",
+    "@shopify/app-bridge": "^1.15.0",
     "@shopify/app-bridge-react": "^1.6.8",
     "@shopify/app-cli-node-generator-helper": "^1.1.2",
     "@shopify/koa-shopify-auth": "^3.1.41",


### PR DESCRIPTION
### WHY are these changes introduced?
Polaris contextual save bar for App Bridge React. The docs recommend to use the app bridge flavour of the contextual save bar rather than the component provided in Polaris. The app bridge GitHub seems private so I thought I'd pop this here to contribute back to the community.

### WHAT is this pull request doing?
- Add /components folder
- Add ContextualSaveBar.js
- Add dep on @shopify/app-bridge
