### PR TITLE
Bump koa-session to v6.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6168,9 +6168,9 @@
       }
     },
     "buffer": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
-      "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
@@ -12440,9 +12440,9 @@
       }
     },
     "koa-session": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/koa-session/-/koa-session-5.13.1.tgz",
-      "integrity": "sha512-TfYiun6xiFosyfIJKnEw0aoG5XmLIwM+K3OVWfkz84qY0NP2gbk0F/olRn0/Hrxq0f14s8amHVXeWyKYH3Cx3Q==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/koa-session/-/koa-session-6.0.0.tgz",
+      "integrity": "sha512-mEj2ximzLqoypk0Q+/JLu0j7fuMk/fL+yiBM0RKmxBqdImKxq3hfnpHLwpMhwya05z/W8i7vawpFl+lsYTZbAg==",
       "requires": {
         "crc": "^3.4.4",
         "debug": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "js-cookie": "^2.2.1",
     "koa": "^2.8.2",
     "koa-router": "^9.0.4",
-    "koa-session": "^5.13.1",
+    "koa-session": "^6.0.0",
     "next": "^8.1.0",
     "next-env": "^1.1.0",
     "react": "^16.10.1",


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-app-cli/issues/895 <!-- link to issue if one exists -->

It's been reported that the node boilerplate code is failing in production with the current version of koa-session, and bumping it to the latest version fixes that issue.

### WHAT is this pull request doing?

Bumping `koa-session` to 6.0.0.