### PR TITLE
Remove superfluous git add from lint-staged hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,8 +67,7 @@
   },
   "lint-staged": {
     "*.{js,css,json,md}": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   }
 }


### PR DESCRIPTION
`lint-staged` now automatically adds any changes to the original commit, making `git add` superfluous (as stated by their own warning).

### WHY are these changes introduced?

_Fixes nothing._

### WHAT is this pull request doing?

Updated package.json `lint-staged` hook.
