### PR TITLE
Remove GraphQL proxy package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4041,23 +4041,6 @@
         "tslib": "^1.9.3"
       }
     },
-    "@shopify/koa-shopify-graphql-proxy": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@shopify/koa-shopify-graphql-proxy/-/koa-shopify-graphql-proxy-4.1.0.tgz",
-      "integrity": "sha512-TYoNHjtRFTvgdlmIAQyjglmHy4j71EL1o1NfuikDUpAmaRjhu8KwF5DLO9VTkdfy2RLgpmva6Mcxvzwncwfj9g==",
-      "requires": {
-        "@types/koa": "^2.0.0",
-        "koa-better-http-proxy": "^0.2.4",
-        "tslib": "^1.14.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
     "@shopify/network": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@shopify/network/-/network-1.5.1.tgz",
@@ -4168,14 +4151,6 @@
         "defer-to-connect": "^1.0.1"
       }
     },
-    "@types/accepts": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
-      "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/babel__core": {
       "version": "7.1.10",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.10.tgz",
@@ -4217,58 +4192,11 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/body-parser": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.1.tgz",
-      "integrity": "sha512-RoX2EZjMiFMjZh9lmYrwgoP9RTpAjSHiJxdp4oidAQVO02T7HER3xj9UKue5534ULWeqVEkujhWcyvUce+d68w==",
-      "requires": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
-    },
-    "@types/connect": {
-      "version": "3.4.33",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
-      "integrity": "sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/cookies": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.4.tgz",
-      "integrity": "sha512-oTGtMzZZAVuEjTwCjIh8T8FrC8n/uwy+PG0yTvQcdZ7etoel7C7/3MSd7qrukENTgQtotG7gvBlBojuVs7X5rw==",
-      "requires": {
-        "@types/connect": "*",
-        "@types/express": "*",
-        "@types/keygrip": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/express": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.2.tgz",
-      "integrity": "sha512-5mHFNyavtLoJmnusB8OKJ5bshSzw+qkMIBAobLrIM48HJvunFva9mOa6aBwh64lBFyNwBbs0xiEFuj4eU/NjCA==",
-      "requires": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "*",
-        "@types/serve-static": "*"
-      }
-    },
-    "@types/express-serve-static-core": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.2.tgz",
-      "integrity": "sha512-El9yMpctM6tORDAiBwZVLMcxoTMcqqRO9dVyYcn7ycLWbvR8klrDn8CAOwRfZujZtWD7yS/mshTdz43jMOejbg==",
-      "requires": {
-        "@types/node": "*",
-        "@types/range-parser": "*"
-      }
     },
     "@types/graceful-fs": {
       "version": "4.1.3",
@@ -4278,11 +4206,6 @@
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@types/http-assert": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.1.tgz",
-      "integrity": "sha512-PGAK759pxyfXE78NbKxyfRcWYA/KwW17X290cNev/qAsn9eQIxkH4shoNBafH37wewhDG/0p1cHPbK6+SzZjWQ=="
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
@@ -4320,37 +4243,6 @@
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@types/keygrip": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
-      "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw=="
-    },
-    "@types/koa": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.11.0.tgz",
-      "integrity": "sha512-Hgx/1/rVlJvqYBrdeCsS7PDiR2qbxlMt1RnmNWD4Uxi5FF9nwkYqIldo7urjc+dfNpk+2NRGcnAYd4L5xEhCcQ==",
-      "requires": {
-        "@types/accepts": "*",
-        "@types/cookies": "*",
-        "@types/http-assert": "*",
-        "@types/keygrip": "*",
-        "@types/koa-compose": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/koa-compose": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.5.tgz",
-      "integrity": "sha512-B8nG/OoE1ORZqCkBVsup/AKcvjdgoHnfi4pZMn5UwAPCbhk/96xyv284eBYW8JlQbQ7zDmnpFr68I/40mFoIBQ==",
-      "requires": {
-        "@types/koa": "*"
-      }
-    },
-    "@types/mime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
-      "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
     },
     "@types/node": {
       "version": "11.13.7",
@@ -4401,11 +4293,6 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
-    "@types/range-parser": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
-      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
-    },
     "@types/react": {
       "version": "16.14.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.2.tgz",
@@ -4429,15 +4316,6 @@
       "integrity": "sha512-/QfLHGpu+2fQOqQaXh8MG9q03bFENooTb/it4jr5kKaZlDQfWvjqWZg48AwzPVMBHlRuTRAY7hRHCEOXz5kV6w==",
       "requires": {
         "@types/react": "*"
-      }
-    },
-    "@types/serve-static": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz",
-      "integrity": "sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==",
-      "requires": {
-        "@types/express-serve-static-core": "*",
-        "@types/mime": "*"
       }
     },
     "@types/stack-utils": {
@@ -5464,11 +5342,6 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
-    },
-    "async": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-      "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
     },
     "async-each": {
       "version": "1.0.3",
@@ -6634,11 +6507,6 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
       "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw=="
     },
-    "colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
-    },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -7242,11 +7110,6 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
       "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
-    },
-    "cycle": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
     },
     "cyclist": {
       "version": "1.0.1",
@@ -8059,11 +7922,6 @@
         "es6-symbol": "^3.1.1"
       }
     },
-    "es6-promise": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
-      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
-    },
     "es6-symbol": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
@@ -8409,11 +8267,6 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
-    },
-    "eyes": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
     },
     "fast-deep-equal": {
       "version": "2.0.1",
@@ -11848,16 +11701,6 @@
           "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
           "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw=="
         }
-      }
-    },
-    "koa-better-http-proxy": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/koa-better-http-proxy/-/koa-better-http-proxy-0.2.5.tgz",
-      "integrity": "sha512-HCVidGuAsYwtYeNJmfhdIZSwr8ak48qAwqvP7++dpUIpta+0Z2iWiwkVgDzqymCyo7hUUSd5Yu0XU70dAh2h8A==",
-      "requires": {
-        "es6-promise": "^3.3.1",
-        "raw-body": "^2.2.0",
-        "winston": "^2.3.1"
       }
     },
     "koa-compose": {
@@ -16260,11 +16103,6 @@
         "figgy-pudding": "^3.5.1"
       }
     },
-    "stack-trace": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
-    },
     "stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -18057,19 +17895,6 @@
       "dev": true,
       "requires": {
         "string-width": "^4.0.0"
-      }
-    },
-    "winston": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.5.tgz",
-      "integrity": "sha512-TWoamHt5yYvsMarGlGEQE59SbJHqGsZV8/lwC+iCcGeAe0vUaOh+Lv6SYM17ouzC/a/LB1/hz/7sxFBtlu1l4A==",
-      "requires": {
-        "async": "~1.0.0",
-        "colors": "1.0.x",
-        "cycle": "1.0.x",
-        "eyes": "0.1.x",
-        "isstream": "0.1.x",
-        "stack-trace": "0.0.x"
       }
     },
     "word-wrap": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@babel/register": "^7.12.10",
     "@shopify/app-bridge-react": "^1.15.0",
     "@shopify/koa-shopify-auth": "^3.2.0",
-    "@shopify/koa-shopify-graphql-proxy": "^4.1.0",
     "@shopify/polaris": "^5.12.0",
     "@shopify/shopify-api": "^0.2.2",
     "@zeit/next-css": "^1.0.1",

--- a/server/server.js
+++ b/server/server.js
@@ -6,7 +6,6 @@ import createShopifyAuth, {
   initializeShopifyKoa,
 } from "@shopify/koa-shopify-auth";
 import Shopify, { ApiVersion } from "@shopify/shopify-api";
-import graphQLProxy from "@shopify/koa-shopify-graphql-proxy";
 import Koa from "koa";
 import next from "next";
 import Router from "koa-router";
@@ -49,11 +48,6 @@ app.prepare().then(() => {
         // Redirect to app with shop parameter upon auth
         ctx.redirect(`/?shop=${shop}`);
       },
-    })
-  );
-  server.use(
-    graphQLProxy({
-      version: ApiVersion.October19,
     })
   );
   router.get("(.*)", verifyRequest(), async (ctx) => {


### PR DESCRIPTION
### WHY are these changes introduced?

The new library will add its own functions to set up a GraphQL proxy, so we will no longer need to import the package. Once that feature is available, we should add it back under the new format.

### WHAT is this pull request doing?

Simply removes the package and its use from the app.