### PR TITLE
Add authenticatedFetch to React App by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4030,6 +4030,14 @@
         "@shopify/app-bridge": "^1.28.0"
       }
     },
+    "@shopify/app-bridge-utils": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@shopify/app-bridge-utils/-/app-bridge-utils-1.28.0.tgz",
+      "integrity": "sha512-zGg3bBUGYpyHj1qP9BzMUJEfUXRKwhgcPyvLaYsgVKK874SmvS7NF5uMNhn2opF41wZxCwRytmVz00bKkpXM1Q==",
+      "requires": {
+        "@shopify/app-bridge": "^1.28.0"
+      }
+    },
     "@shopify/koa-shopify-auth": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@shopify/koa-shopify-auth/-/koa-shopify-auth-3.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@babel/preset-env": "^7.12.11",
     "@babel/register": "^7.12.10",
     "@shopify/app-bridge-react": "^1.15.0",
+    "@shopify/app-bridge-utils": "^1.28.0",
     "@shopify/koa-shopify-auth": "^3.2.0",
     "@shopify/koa-shopify-graphql-proxy": "^4.1.0",
     "@shopify/polaris": "^5.12.0",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,18 +1,31 @@
-import fetch from "node-fetch";
 import ApolloClient from "apollo-boost";
 import { ApolloProvider } from "react-apollo";
 import App from "next/app";
 import { AppProvider } from "@shopify/polaris";
-import { Provider } from "@shopify/app-bridge-react";
+import { Provider, useAppBridge } from "@shopify/app-bridge-react";
+import { authenticatedFetch } from "@shopify/app-bridge-utils";
 import "@shopify/polaris/dist/styles.css";
 import translations from "@shopify/polaris/locales/en.json";
 
-const client = new ApolloClient({
-  fetch: fetch,
-  fetchOptions: {
-    credentials: "include",
-  },
-});
+function MyProvider(props) {
+  const app = useAppBridge();
+
+  const client = new ApolloClient({
+    fetch: authenticatedFetch(app),
+    fetchOptions: {
+      credentials: "include",
+    },
+  });
+
+  const Component = props.Component;
+
+  return (
+    <ApolloProvider client={client}>
+      <Component {...props} />
+    </ApolloProvider>
+  );
+}
+
 class MyApp extends App {
   render() {
     const { Component, pageProps, shopOrigin } = this.props;
@@ -25,9 +38,7 @@ class MyApp extends App {
             forceRedirect: true,
           }}
         >
-          <ApolloProvider client={client}>
-            <Component {...pageProps} />
-          </ApolloProvider>
+          <MyProvider Component={Component} {...pageProps} />
         </Provider>
       </AppProvider>
     );


### PR DESCRIPTION
### WHY are these changes introduced?

This app is set to be embedded by default, so we should make sure that the client side is equipped to make JWT-based requests from the get-go.

### WHAT is this pull request doing?

Adding `app-bridge-utils` so we can leverage `authenticatedFetch` in our App component, which abstracts all of the logic of setting up the session token. With this, requests to the server will include the `Authorization: Bearer XYZ` header and therefore transparently enable these requests to match to the current session.