### PR TITLE
Use unauthenticated root path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6456,6 +6456,17 @@
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
+    "co-body": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/co-body/-/co-body-6.1.0.tgz",
+      "integrity": "sha512-m7pOT6CdLN7FuXUcpuz/8lfQ/L77x8SchHCF4G0RBTJO20Wzmhn5Sp4/5WsKy8OSpifBSUrmg83qEqaDHdyFuQ==",
+      "requires": {
+        "inflation": "^2.0.0",
+        "qs": "^6.5.2",
+        "raw-body": "^2.3.3",
+        "type-is": "^1.6.16"
+      }
+    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -6696,6 +6707,11 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+    },
+    "copy-to": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/copy-to/-/copy-to-2.0.1.tgz",
+      "integrity": "sha1-JoD7uAaKSNCGVrYJgJK9r8kG9KU="
     },
     "core-js": {
       "version": "2.6.5",
@@ -9295,6 +9311,11 @@
       "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
       "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="
     },
+    "inflation": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/inflation/-/inflation-2.0.0.tgz",
+      "integrity": "sha1-i0F+R8KPklpFEz2RTKH9OJEH8w8="
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -11709,6 +11730,15 @@
           "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
           "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw=="
         }
+      }
+    },
+    "koa-bodyparser": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/koa-bodyparser/-/koa-bodyparser-4.3.0.tgz",
+      "integrity": "sha512-uyV8G29KAGwZc4q/0WUAjH+Tsmuv9ImfBUF2oZVyZtaeo0husInagyn/JH85xMSxM0hEk/mbCII5ubLDuqW/Rw==",
+      "requires": {
+        "co-body": "^6.0.0",
+        "copy-to": "^2.0.1"
       }
     },
     "koa-compose": {
@@ -14734,8 +14764,7 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "dev": true
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "querystring": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "graphql": "^14.5.8",
     "isomorphic-fetch": "^3.0.0",
     "koa": "^2.13.1",
+    "koa-bodyparser": "^4.3.0",
     "koa-router": "^10.0.0",
     "koa-session": "^6.1.0",
     "next": "^10.0.4",


### PR DESCRIPTION
### WHY are these changes introduced?

The current implementation of the app still relied on 3rd party cookies for the initial `/` load to fetch the app skeleton, which still caused it to fail if one attempted to reach the app by clicking the Admin link to it.

### WHAT is this pull request doing?

I added an sqlite database to the app so we can store the shops to which it's been installed. Since we now have a means of persisting data, I also went ahead and added a `CustomSessionStorage` object which also leverages it to provide persistent sessions.