### PR TITLE
Bump koa-shopify-auth dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4039,9 +4039,9 @@
       }
     },
     "@shopify/koa-shopify-auth": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@shopify/koa-shopify-auth/-/koa-shopify-auth-4.0.0.tgz",
-      "integrity": "sha512-FGU0F0VnWLfrRzYonq0kMNag7EJ+LJXmbVNcUDSJvklwI1aU8KCaMkn6lORbbRV16UF9rsJi9NIpshAWdg60Ag==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@shopify/koa-shopify-auth/-/koa-shopify-auth-4.0.1.tgz",
+      "integrity": "sha512-3BnipOVOeLtajVqVQ/w/yqgNX8OvEeKnwVnRWMnj1vYSIvWJxXKqzfAbFYujPb1V0r/h2xs/+/M7l5vdolgTCg==",
       "requires": {
         "@shopify/network": "^1.5.0",
         "@shopify/shopify-api": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@babel/register": "^7.12.10",
     "@shopify/app-bridge-react": "^1.15.0",
     "@shopify/app-bridge-utils": "^1.28.0",
-    "@shopify/koa-shopify-auth": "^4.0.0",
+    "@shopify/koa-shopify-auth": "^4.0.1",
     "@shopify/polaris": "^5.12.0",
     "@zeit/next-css": "^1.0.1",
     "apollo-boost": "^0.4.9",


### PR DESCRIPTION
The Koa library was updated to ensure we're always sending the proper user agent, this is just bumping that dependency to make sure we're using it.