### PR TITLE
Add ESM support for .mjs files in the nextjs config 

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,9 +5,17 @@ const webpack = require("webpack");
 const apiKey = JSON.stringify(process.env.SHOPIFY_API_KEY);
 
 module.exports = withCSS({
-  webpack: config => {
+  webpack: (config) => {
     const env = { API_KEY: apiKey };
     config.plugins.push(new webpack.DefinePlugin(env));
+
+    // Add ESM support for .mjs files in webpack 4
+    config.module.rules.push({
+      test: /\.mjs$/,
+      include: /node_modules/,
+      type: "javascript/auto",
+    });
+
     return config;
-  }
+  },
 });


### PR DESCRIPTION
### WHY are these changes introduced?
In `shopify/quilt`, we updated our package builds to provide an [ESM build](https://github.com/Shopify/quilt/pull/1698) for consumers. This provides apps with more tree-shakable builds resulting in smaller production builds. Internally, our tooling is already configured to support these builds, though this boilerplate app isn't (see https://github.com/Shopify/quilt/issues/1722). 

Fixes https://github.com/Shopify/quilt/issues/1722


### WHAT is this pull request doing?

Adding out of the box support for ESM (`.mjs` files) libraries (Packages living in `shopify/quilt`)