### PR TITLE
Handle redirect header on proxy requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@babel/register": "^7.12.10",
         "@shopify/app-bridge-react": "^1.15.0",
         "@shopify/app-bridge-utils": "^1.28.0",
-        "@shopify/koa-shopify-auth": "^4.0.3",
+        "@shopify/koa-shopify-auth": "^4.1.0",
         "@shopify/polaris": "^5.12.0",
         "apollo-boost": "^0.4.9",
         "cross-env": "^7.0.3",
@@ -4470,9 +4470,9 @@
       }
     },
     "node_modules/@shopify/koa-shopify-auth": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@shopify/koa-shopify-auth/-/koa-shopify-auth-4.0.3.tgz",
-      "integrity": "sha512-yf/qe2vjf4Mc6qCFtqRisBERhxyDyLwynsf1rJuPL5+3zKIJNUUS94wPjByyXaDqd8L8Oa0wzz8vZ7otX+DFGg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@shopify/koa-shopify-auth/-/koa-shopify-auth-4.1.0.tgz",
+      "integrity": "sha512-VUxTlLpiMKGQb/Sp6kP9md88Y4khQ0e9tyuyw2No/8d0WJ44RBhKbRbXnMIFK4C2oS9F9sqWOeMY/ncAk+kRiA==",
       "license": "MIT",
       "dependencies": {
         "@shopify/network": "^1.5.0",
@@ -18005,6 +18005,7 @@
       "version": "0.26.2",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.26.2.tgz",
       "integrity": "sha512-bGBPCxRAvdK9bX5HokqEYma4j/Q5+w8Nrmb2/sfgQCLEUx/HblcpmOfp59obL3+knIKnOhyKmDb4tEOhvFlp6Q==",
+      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "color": "^3.1.2",
@@ -24953,9 +24954,9 @@
       }
     },
     "@shopify/koa-shopify-auth": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@shopify/koa-shopify-auth/-/koa-shopify-auth-4.0.3.tgz",
-      "integrity": "sha512-yf/qe2vjf4Mc6qCFtqRisBERhxyDyLwynsf1rJuPL5+3zKIJNUUS94wPjByyXaDqd8L8Oa0wzz8vZ7otX+DFGg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@shopify/koa-shopify-auth/-/koa-shopify-auth-4.1.0.tgz",
+      "integrity": "sha512-VUxTlLpiMKGQb/Sp6kP9md88Y4khQ0e9tyuyw2No/8d0WJ44RBhKbRbXnMIFK4C2oS9F9sqWOeMY/ncAk+kRiA==",
       "requires": {
         "@shopify/network": "^1.5.0",
         "@shopify/shopify-api": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@babel/register": "^7.12.10",
     "@shopify/app-bridge-react": "^1.15.0",
     "@shopify/app-bridge-utils": "^1.28.0",
-    "@shopify/koa-shopify-auth": "^4.0.3",
+    "@shopify/koa-shopify-auth": "^4.1.0",
     "@shopify/polaris": "^5.12.0",
     "apollo-boost": "^0.4.9",
     "cross-env": "^7.0.3",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -4,14 +4,37 @@ import App from "next/app";
 import { AppProvider } from "@shopify/polaris";
 import { Provider, useAppBridge } from "@shopify/app-bridge-react";
 import { authenticatedFetch } from "@shopify/app-bridge-utils";
+import { Redirect } from "@shopify/app-bridge/actions";
 import "@shopify/polaris/dist/styles.css";
 import translations from "@shopify/polaris/locales/en.json";
+
+function userLoggedInFetch(app) {
+  const fetchFunction = authenticatedFetch(app);
+
+  return async (uri, options) => {
+    const response = await fetchFunction(uri, options);
+
+    if (
+      response.headers.get("X-Shopify-API-Request-Failure-Reauthorize") === "1"
+    ) {
+      const authUrlHeader = response.headers.get(
+        "X-Shopify-API-Request-Failure-Reauthorize-Url"
+      );
+
+      const redirect = Redirect.create(app);
+      redirect.dispatch(Redirect.Action.APP, authUrlHeader || `/auth`);
+      return null;
+    }
+
+    return response;
+  };
+}
 
 function MyProvider(props) {
   const app = useAppBridge();
 
   const client = new ApolloClient({
-    fetch: authenticatedFetch(app),
+    fetch: userLoggedInFetch(app),
     fetchOptions: {
       credentials: "include",
     },

--- a/server/server.js
+++ b/server/server.js
@@ -88,9 +88,13 @@ app.prepare().then(async () => {
     }
   });
 
-  router.post("/graphql", verifyRequest(), async (ctx, next) => {
-    await Shopify.Utils.graphqlProxy(ctx.req, ctx.res);
-  });
+  router.post(
+    "/graphql",
+    verifyRequest({ returnHeader: true }),
+    async (ctx, next) => {
+      await Shopify.Utils.graphqlProxy(ctx.req, ctx.res);
+    }
+  );
 
   router.get("(/_next/static/.*)", handleRequest); // Static content is clear
   router.get("/_next/webpack-hmr", handleRequest); // Webpack content is clear


### PR DESCRIPTION
### WHY are these changes introduced?

`@shopify/koa-shopify-auth` added support for returning a header indicating the auth URL to redirect to instead of the `Location` header, so that the GraphQL proxy (and other XHR requests) can also trigger the OAuth flow when a session expires.

### WHAT is this pull request doing?

Toggling the feature to return a header on, and wrapping the `authenticatedFetch` in a custom function that looks for the presence of that header and triggers an App Bridge redirect to it.