### PR TITLE
Bumping koa-shopify-auth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@babel/register": "^7.12.10",
         "@shopify/app-bridge-react": "^1.15.0",
         "@shopify/app-bridge-utils": "^1.28.0",
-        "@shopify/koa-shopify-auth": "^4.1.0",
+        "@shopify/koa-shopify-auth": "^4.1.2",
         "@shopify/polaris": "^5.12.0",
         "apollo-boost": "^0.4.9",
         "cross-env": "^7.0.3",
@@ -4470,22 +4470,22 @@
       }
     },
     "node_modules/@shopify/koa-shopify-auth": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@shopify/koa-shopify-auth/-/koa-shopify-auth-4.1.0.tgz",
-      "integrity": "sha512-VUxTlLpiMKGQb/Sp6kP9md88Y4khQ0e9tyuyw2No/8d0WJ44RBhKbRbXnMIFK4C2oS9F9sqWOeMY/ncAk+kRiA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@shopify/koa-shopify-auth/-/koa-shopify-auth-4.1.2.tgz",
+      "integrity": "sha512-lKr7L6mgSvYg5B90SZYTznvLKKeqdxW9I83g5rM6N5t++b0l627ecqVcjdjPcSeX0PbofXsXRyCHdgnizzi8vw==",
       "license": "MIT",
       "dependencies": {
         "@shopify/network": "^1.5.0",
-        "@shopify/shopify-api": "^1.2.0",
+        "@shopify/shopify-api": "^1.2.1",
         "koa-compose": ">=3.0.0 <4.0.0",
         "nonce": "^1.0.4",
         "tslib": "^1.9.3"
       }
     },
     "node_modules/@shopify/network": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@shopify/network/-/network-1.6.2.tgz",
-      "integrity": "sha512-7Zjf3VHOFfih4pAEWPzFICd2oW/bxglfCgMMsUQfVxyLZtEms6a74X2COSkihRfr4nQ9fU1nF1bTjLFfcUxFbQ==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@shopify/network/-/network-1.6.3.tgz",
+      "integrity": "sha512-eR7fsyprdzybhSfoZsW94fF1do/iVebRYpG8LkUOD0tVTddFlbXA+ivbL1VZ+BqUjbYnwQ1OHDQ45CyPGpjGzw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^1.14.1"
@@ -4530,9 +4530,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@shopify/shopify-api": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@shopify/shopify-api/-/shopify-api-1.2.0.tgz",
-      "integrity": "sha512-/dw40VBJCS4mViNrI1kBJYp08FeNKgUDiUdt6nnbgioooLEdAEMHJq3uy1Qo9q3SraIsSOPVMjtqnCcKM0XHbg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@shopify/shopify-api/-/shopify-api-1.2.1.tgz",
+      "integrity": "sha512-a2xNAQovf8WYGEAvjrdSK2bY3+XWuFgIfPhtxkO+QAMILb3dIk+Cxtbo1gaC1fD170AjwZ6gVl5RQbpe9ZVsfw==",
       "license": "MIT",
       "dependencies": {
         "@shopify/network": "^1.5.1",
@@ -24954,21 +24954,21 @@
       }
     },
     "@shopify/koa-shopify-auth": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@shopify/koa-shopify-auth/-/koa-shopify-auth-4.1.0.tgz",
-      "integrity": "sha512-VUxTlLpiMKGQb/Sp6kP9md88Y4khQ0e9tyuyw2No/8d0WJ44RBhKbRbXnMIFK4C2oS9F9sqWOeMY/ncAk+kRiA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@shopify/koa-shopify-auth/-/koa-shopify-auth-4.1.2.tgz",
+      "integrity": "sha512-lKr7L6mgSvYg5B90SZYTznvLKKeqdxW9I83g5rM6N5t++b0l627ecqVcjdjPcSeX0PbofXsXRyCHdgnizzi8vw==",
       "requires": {
         "@shopify/network": "^1.5.0",
-        "@shopify/shopify-api": "^1.2.0",
+        "@shopify/shopify-api": "^1.2.1",
         "koa-compose": ">=3.0.0 <4.0.0",
         "nonce": "^1.0.4",
         "tslib": "^1.9.3"
       }
     },
     "@shopify/network": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@shopify/network/-/network-1.6.2.tgz",
-      "integrity": "sha512-7Zjf3VHOFfih4pAEWPzFICd2oW/bxglfCgMMsUQfVxyLZtEms6a74X2COSkihRfr4nQ9fU1nF1bTjLFfcUxFbQ==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@shopify/network/-/network-1.6.3.tgz",
+      "integrity": "sha512-eR7fsyprdzybhSfoZsW94fF1do/iVebRYpG8LkUOD0tVTddFlbXA+ivbL1VZ+BqUjbYnwQ1OHDQ45CyPGpjGzw==",
       "requires": {
         "tslib": "^1.14.1"
       },
@@ -25016,9 +25016,9 @@
       }
     },
     "@shopify/shopify-api": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@shopify/shopify-api/-/shopify-api-1.2.0.tgz",
-      "integrity": "sha512-/dw40VBJCS4mViNrI1kBJYp08FeNKgUDiUdt6nnbgioooLEdAEMHJq3uy1Qo9q3SraIsSOPVMjtqnCcKM0XHbg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@shopify/shopify-api/-/shopify-api-1.2.1.tgz",
+      "integrity": "sha512-a2xNAQovf8WYGEAvjrdSK2bY3+XWuFgIfPhtxkO+QAMILb3dIk+Cxtbo1gaC1fD170AjwZ6gVl5RQbpe9ZVsfw==",
       "requires": {
         "@shopify/network": "^1.5.1",
         "@types/jsonwebtoken": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@babel/register": "^7.12.10",
     "@shopify/app-bridge-react": "^1.15.0",
     "@shopify/app-bridge-utils": "^1.28.0",
-    "@shopify/koa-shopify-auth": "^4.1.0",
+    "@shopify/koa-shopify-auth": "^4.1.2",
     "@shopify/polaris": "^5.12.0",
     "apollo-boost": "^0.4.9",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
Bumping `koa-shopify-auth` to the latest version which stops using the `SameSite=none` setting altogether for cookies.