### PR TITLE
Fix redirection inconsistency and simplify routing for "multi-page" apps

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -69,17 +69,6 @@ app.prepare().then(async () => {
     ctx.res.statusCode = 200;
   };
 
-  router.get("/", async (ctx) => {
-    const shop = ctx.query.shop;
-
-    // This shop hasn't been seen yet, go through OAuth to create a session
-    if (ACTIVE_SHOPIFY_SHOPS[shop] === undefined) {
-      ctx.redirect(`/auth?shop=${shop}`);
-    } else {
-      await handleRequest(ctx);
-    }
-  });
-
   router.post("/webhooks", async (ctx) => {
     try {
       await Shopify.Webhooks.Registry.process(ctx.req, ctx.res);
@@ -99,7 +88,16 @@ app.prepare().then(async () => {
 
   router.get("(/_next/static/.*)", handleRequest); // Static content is clear
   router.get("/_next/webpack-hmr", handleRequest); // Webpack content is clear
-  router.get("(.*)", verifyRequest(), handleRequest); // Everything else must have sessions
+  router.get("(.*)", async (ctx) => {
+    const shop = ctx.query.shop;
+
+    // This shop hasn't been seen yet, go through OAuth to create a session
+    if (ACTIVE_SHOPIFY_SHOPS[shop] === undefined) {
+      ctx.redirect(`/auth?shop=${shop}`);
+    } else {
+      await handleRequest(ctx);
+    }
+  });
 
   server.use(router.allowedMethods());
   server.use(router.routes());


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Related to #311
Related to #76

The current routing setup results in users being redirected to the app root when the app is reloaded (regardless of what path the user is currently on).

### WHAT is this pull request doing?
This pull request replaces the routing logic for all pages with the current routing logic for the root page, which will prompt a user to go through OAuth if there is no current session, but will redirect them to the current context afterwards.

cc @paulomarg 
