### PR TITLE
Removed react-apollo and apollo-boost and updated to apollo client v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@apollo/client": "^3.3.20",
         "@babel/core": "7.12.10",
         "@babel/polyfill": "^7.6.0",
         "@babel/preset-env": "^7.12.11",
@@ -16,7 +17,6 @@
         "@shopify/app-bridge-utils": "^2.0.2",
         "@shopify/koa-shopify-auth": "^4.1.2",
         "@shopify/polaris": "^6.2.0",
-        "apollo-boost": "^0.4.9",
         "cross-env": "^7.0.3",
         "dotenv": "^8.2.0",
         "graphql": "^14.5.8",
@@ -28,7 +28,6 @@
         "next-env": "^1.1.0",
         "node-fetch": "^2.6.1",
         "react": "^16.10.1",
-        "react-apollo": "^3.1.3",
         "react-dom": "^16.10.1",
         "webpack": "^4.44.1"
       },
@@ -222,91 +221,40 @@
         "cross-fetch": "3.0.6"
       }
     },
-    "node_modules/@apollo/react-common": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@apollo/react-common/-/react-common-3.1.4.tgz",
-      "integrity": "sha512-X5Kyro73bthWSCBJUC5XYQqMnG0dLWuDZmVkzog9dynovhfiVCV4kPSdgSIkqnb++cwCzOVuQ4rDKVwo2XRzQA==",
+    "node_modules/@apollo/client": {
+      "version": "3.3.20",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.20.tgz",
+      "integrity": "sha512-hS7UmBwJweudw/J3M0RAcusMHNiRuGqkRH6g91PM2ev8cXScIMdXr/++9jo7wD1nAITMCMF4HQQ3LFaw/Or0Bw==",
       "dependencies": {
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
-      }
-    },
-    "node_modules/@apollo/react-common/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@apollo/react-components": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-components/-/react-components-3.1.5.tgz",
-      "integrity": "sha512-c82VyUuE9VBnJB7bnX+3dmwpIPMhyjMwyoSLyQWPHxz8jK4ak30XszJtqFf4eC4hwvvLYa+Ou6X73Q8V8e2/jg==",
-      "dependencies": {
-        "@apollo/react-common": "^3.1.4",
-        "@apollo/react-hooks": "^3.1.5",
+        "@graphql-typed-document-node/core": "^3.0.0",
+        "@types/zen-observable": "^0.8.0",
+        "@wry/context": "^0.6.0",
+        "@wry/equality": "^0.5.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graphql-tag": "^2.12.0",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.16.0",
         "prop-types": "^15.7.2",
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.7.0",
+        "tslib": "^1.10.0",
+        "zen-observable": "^0.8.14"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0",
+        "react": "^16.8.0 || ^17.0.0",
+        "subscriptions-transport-ws": "^0.9.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "subscriptions-transport-ws": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@apollo/react-components/node_modules/prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
-      }
-    },
-    "node_modules/@apollo/react-components/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@apollo/react-hoc": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-hoc/-/react-hoc-3.1.5.tgz",
-      "integrity": "sha512-jlZ2pvEnRevLa54H563BU0/xrYSgWQ72GksarxUzCHQW85nmn9wQln0kLBX7Ua7SBt9WgiuYQXQVechaaCulfQ==",
-      "dependencies": {
-        "@apollo/react-common": "^3.1.4",
-        "@apollo/react-components": "^3.1.5",
-        "hoist-non-react-statics": "^3.3.0",
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
-      }
-    },
-    "node_modules/@apollo/react-hoc/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@apollo/react-hooks": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-hooks/-/react-hooks-3.1.5.tgz",
-      "integrity": "sha512-y0CJ393DLxIIkksRup4nt+vSjxalbZBXnnXxYbviq/woj+zKa431zy0yT4LqyRKpFy9ahMIwxBnBwfwIoupqLQ==",
-      "dependencies": {
-        "@apollo/react-common": "^3.1.4",
-        "@wry/equality": "^0.1.9",
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
-      }
-    },
-    "node_modules/@apollo/react-hooks/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@apollo/react-ssr": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-ssr/-/react-ssr-3.1.5.tgz",
-      "integrity": "sha512-wuLPkKlctNn3u8EU8rlECyktpOUCeekFfb0KhIKknpGY6Lza2Qu0bThx7D9MIbVEzhKadNNrzLcpk0Y8/5UuWg==",
-      "dependencies": {
-        "@apollo/react-common": "^3.1.4",
-        "@apollo/react-hooks": "^3.1.5",
-        "tslib": "^1.10.0"
-      }
-    },
-    "node_modules/@apollo/react-ssr/node_modules/tslib": {
+    "node_modules/@apollo/client/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
@@ -3296,6 +3244,14 @@
         "node": ">=0.1.95"
       }
     },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.0.tgz",
+      "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+      }
+    },
     "node_modules/@hapi/accept": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.1.tgz",
@@ -4980,21 +4936,52 @@
       }
     },
     "node_modules/@wry/context": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.4.4.tgz",
-      "integrity": "sha512-LrKVLove/zw6h2Md/KZyWxIkFM6AoyKp71OqpH9Hiip1csjPVoD3tPxlbQUNxEnHENks3UGgNpSBCAfq9KWuag==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.0.tgz",
+      "integrity": "sha512-sAgendOXR8dM7stJw3FusRxFHF/ZinU0lffsA2YTyyIOfic86JX02qlPqPVqJNZJPAxFt+2EE8bvq6ZlS0Kf+Q==",
       "dependencies": {
-        "@types/node": ">=6",
-        "tslib": "^1.9.3"
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
+    "node_modules/@wry/context/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+    },
     "node_modules/@wry/equality": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.9.tgz",
-      "integrity": "sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.1.tgz",
+      "integrity": "sha512-FZKbdpbcVcbDxQrKcaBClNsQaMg9nof1RKM7mReJe5DKUzM5u8S7T+PqwNqvib5O2j2xxF1R4p5O3+b6baTrbw==",
       "dependencies": {
-        "tslib": "^1.9.3"
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
+    },
+    "node_modules/@wry/equality/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+    },
+    "node_modules/@wry/trie": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.0.tgz",
+      "integrity": "sha512-Yw1akIogPhAT6XPYsRHlZZIS0tIGmAl9EYXHi2scf7LPKKqdqmow/Hu4kEqP2cJR3EjaU/9L0ZlAjFf3hFxmug==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/trie/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
@@ -5274,17 +5261,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/airbnb-prop-types/node_modules/prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
-      }
-    },
     "node_modules/airbnb-prop-types/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -5450,135 +5426,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/apollo-boost": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/apollo-boost/-/apollo-boost-0.4.9.tgz",
-      "integrity": "sha512-05y5BKcDaa8w47f8d81UVwKqrAjn8uKLv6QM9fNdldoNzQ+rnOHgFlnrySUZRz9QIT3vPftQkEz2UEASp1Mi5g==",
-      "dependencies": {
-        "apollo-cache": "^1.3.5",
-        "apollo-cache-inmemory": "^1.6.6",
-        "apollo-client": "^2.6.10",
-        "apollo-link": "^1.0.6",
-        "apollo-link-error": "^1.0.3",
-        "apollo-link-http": "^1.3.1",
-        "graphql-tag": "^2.4.2",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0"
-      }
-    },
-    "node_modules/apollo-boost/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/apollo-cache": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.5.tgz",
-      "integrity": "sha512-1XoDy8kJnyWY/i/+gLTEbYLnoiVtS8y7ikBr/IfmML4Qb+CM7dEEbIUOjnY716WqmZ/UpXIxTfJsY7rMcqiCXA==",
-      "dependencies": {
-        "apollo-utilities": "^1.3.4",
-        "tslib": "^1.10.0"
-      }
-    },
-    "node_modules/apollo-cache-inmemory": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.6.tgz",
-      "integrity": "sha512-L8pToTW/+Xru2FFAhkZ1OA9q4V4nuvfoPecBM34DecAugUZEBhI2Hmpgnzq2hTKZ60LAMrlqiASm0aqAY6F8/A==",
-      "dependencies": {
-        "apollo-cache": "^1.3.5",
-        "apollo-utilities": "^1.3.4",
-        "optimism": "^0.10.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0"
-      }
-    },
-    "node_modules/apollo-cache-inmemory/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/apollo-cache/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/apollo-client": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.10.tgz",
-      "integrity": "sha512-jiPlMTN6/5CjZpJOkGeUV0mb4zxx33uXWdj/xQCfAMkuNAC3HN7CvYDyMHHEzmcQ5GV12LszWoQ/VlxET24CtA==",
-      "dependencies": {
-        "@types/zen-observable": "^0.8.0",
-        "apollo-cache": "1.3.5",
-        "apollo-link": "^1.0.0",
-        "apollo-utilities": "1.3.4",
-        "symbol-observable": "^1.0.2",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0",
-        "zen-observable": "^0.8.0"
-      }
-    },
-    "node_modules/apollo-client/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/apollo-link": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
-      "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
-      "dependencies": {
-        "apollo-utilities": "^1.3.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3",
-        "zen-observable-ts": "^0.8.21"
-      }
-    },
-    "node_modules/apollo-link-error": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/apollo-link-error/-/apollo-link-error-1.1.13.tgz",
-      "integrity": "sha512-jAZOOahJU6bwSqb2ZyskEK1XdgUY9nkmeclCrW7Gddh1uasHVqmoYc4CKdb0/H0Y1J9lvaXKle2Wsw/Zx1AyUg==",
-      "dependencies": {
-        "apollo-link": "^1.2.14",
-        "apollo-link-http-common": "^0.2.16",
-        "tslib": "^1.9.3"
-      }
-    },
-    "node_modules/apollo-link-http": {
-      "version": "1.5.17",
-      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.17.tgz",
-      "integrity": "sha512-uWcqAotbwDEU/9+Dm9e1/clO7hTB2kQ/94JYcGouBVLjoKmTeJTUPQKcJGpPwUjZcSqgYicbFqQSoJIW0yrFvg==",
-      "dependencies": {
-        "apollo-link": "^1.2.14",
-        "apollo-link-http-common": "^0.2.16",
-        "tslib": "^1.9.3"
-      }
-    },
-    "node_modules/apollo-link-http-common": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.16.tgz",
-      "integrity": "sha512-2tIhOIrnaF4UbQHf7kjeQA/EmSorB7+HyJIIrUjJOKBgnXwuexi8aMecRlqTIDWcyVXCeqLhUnztMa6bOH/jTg==",
-      "dependencies": {
-        "apollo-link": "^1.2.14",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3"
-      }
-    },
-    "node_modules/apollo-utilities": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.4.tgz",
-      "integrity": "sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==",
-      "dependencies": {
-        "@wry/equality": "^0.1.2",
-        "fast-json-stable-stringify": "^2.0.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0"
-      }
-    },
-    "node_modules/apollo-utilities/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/aproba": {
       "version": "1.2.0",
@@ -8545,17 +8392,6 @@
         "semver": "^5.7.0"
       }
     },
-    "node_modules/enzyme-adapter-react-16/node_modules/prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
-      }
-    },
     "node_modules/enzyme-adapter-react-16/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -8574,17 +8410,6 @@
         "object.fromentries": "^2.0.2",
         "prop-types": "^15.7.2",
         "semver": "^5.7.1"
-      }
-    },
-    "node_modules/enzyme-adapter-utils/node_modules/prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
       }
     },
     "node_modules/enzyme-adapter-utils/node_modules/semver": {
@@ -9872,9 +9697,23 @@
       }
     },
     "node_modules/graphql-tag": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.11.0.tgz",
-      "integrity": "sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA=="
+      "version": "2.12.5",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.5.tgz",
+      "integrity": "sha512-5xNhP4063d16Pz3HBtKprutsPrmHZi5IdUGOWRxA2B6VF7BIRGOHZ5WQvDmJXZuPcBg7rYwaFxvQYjqkSdR3TQ==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/graphql-tag/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
     },
     "node_modules/growly": {
       "version": "1.3.0",
@@ -15073,16 +14912,6 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ=="
     },
-    "node_modules/next/node_modules/prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
-      }
-    },
     "node_modules/next/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -16033,11 +15862,12 @@
       }
     },
     "node_modules/optimism": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.10.3.tgz",
-      "integrity": "sha512-9A5pqGoQk49H6Vhjb9kPgAeeECfUDF6aIICbMDL23kDLStBn1MWk3YvcZ4xWF9CsSf6XEgvRLkXy4xof/56vVw==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
+      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
       "dependencies": {
-        "@wry/context": "^0.4.0"
+        "@wry/context": "^0.6.0",
+        "@wry/trie": "^0.3.0"
       }
     },
     "node_modules/optionator": {
@@ -16728,12 +16558,13 @@
       }
     },
     "node_modules/prop-types": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
       "dependencies": {
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
       }
     },
     "node_modules/prop-types-exact": {
@@ -16967,18 +16798,6 @@
       "resolved": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.6.2.tgz",
       "integrity": "sha1-wStu/cIkfBDae4dw0YUICnsEcVY=",
       "dev": true
-    },
-    "node_modules/react-apollo": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/react-apollo/-/react-apollo-3.1.5.tgz",
-      "integrity": "sha512-xOxMqxORps+WHrUYbjVHPliviomefOpu5Sh35oO3osuOyPTxvrljdfTLGCggMhcXBsDljtS5Oy4g+ijWg3D4JQ==",
-      "dependencies": {
-        "@apollo/react-common": "^3.1.4",
-        "@apollo/react-components": "^3.1.5",
-        "@apollo/react-hoc": "^3.1.5",
-        "@apollo/react-hooks": "^3.1.5",
-        "@apollo/react-ssr": "^3.1.5"
-      }
     },
     "node_modules/react-dom": {
       "version": "16.14.0",
@@ -18008,6 +17827,7 @@
       "version": "0.26.2",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.26.2.tgz",
       "integrity": "sha512-bGBPCxRAvdK9bX5HokqEYma4j/Q5+w8Nrmb2/sfgQCLEUx/HblcpmOfp59obL3+knIKnOhyKmDb4tEOhvFlp6Q==",
+      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "color": "^3.1.2",
@@ -19188,11 +19008,11 @@
       }
     },
     "node_modules/symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=0.10"
       }
     },
     "node_modules/symbol-tree": {
@@ -19667,12 +19487,20 @@
       }
     },
     "node_modules/ts-invariant": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
-      "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.7.5.tgz",
+      "integrity": "sha512-qfVyqTYWEqADMtncLqwpUdMjMSXnsqOeqGtj1LeJNFDjz8oqZ1YxLEp29YCOq65z0LgEiERqQ8ThVjnfibJNpg==",
       "dependencies": {
-        "tslib": "^1.9.3"
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
+    },
+    "node_modules/ts-invariant/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
     },
     "node_modules/ts-pnp": {
       "version": "1.2.0",
@@ -20888,15 +20716,6 @@
       "version": "0.8.15",
       "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
       "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
-    },
-    "node_modules/zen-observable-ts": {
-      "version": "0.8.21",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
-      "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
-      "dependencies": {
-        "tslib": "^1.9.3",
-        "zen-observable": "^0.8.0"
-      }
     }
   },
   "dependencies": {
@@ -21057,96 +20876,24 @@
         "cross-fetch": "3.0.6"
       }
     },
-    "@apollo/react-common": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@apollo/react-common/-/react-common-3.1.4.tgz",
-      "integrity": "sha512-X5Kyro73bthWSCBJUC5XYQqMnG0dLWuDZmVkzog9dynovhfiVCV4kPSdgSIkqnb++cwCzOVuQ4rDKVwo2XRzQA==",
+    "@apollo/client": {
+      "version": "3.3.20",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.20.tgz",
+      "integrity": "sha512-hS7UmBwJweudw/J3M0RAcusMHNiRuGqkRH6g91PM2ev8cXScIMdXr/++9jo7wD1nAITMCMF4HQQ3LFaw/Or0Bw==",
       "requires": {
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@apollo/react-components": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-components/-/react-components-3.1.5.tgz",
-      "integrity": "sha512-c82VyUuE9VBnJB7bnX+3dmwpIPMhyjMwyoSLyQWPHxz8jK4ak30XszJtqFf4eC4hwvvLYa+Ou6X73Q8V8e2/jg==",
-      "requires": {
-        "@apollo/react-common": "^3.1.4",
-        "@apollo/react-hooks": "^3.1.5",
+        "@graphql-typed-document-node/core": "^3.0.0",
+        "@types/zen-observable": "^0.8.0",
+        "@wry/context": "^0.6.0",
+        "@wry/equality": "^0.5.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graphql-tag": "^2.12.0",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.16.0",
         "prop-types": "^15.7.2",
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "prop-types": {
-          "version": "15.7.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "object-assign": "^4.1.1",
-            "react-is": "^16.8.1"
-          }
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@apollo/react-hoc": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-hoc/-/react-hoc-3.1.5.tgz",
-      "integrity": "sha512-jlZ2pvEnRevLa54H563BU0/xrYSgWQ72GksarxUzCHQW85nmn9wQln0kLBX7Ua7SBt9WgiuYQXQVechaaCulfQ==",
-      "requires": {
-        "@apollo/react-common": "^3.1.4",
-        "@apollo/react-components": "^3.1.5",
-        "hoist-non-react-statics": "^3.3.0",
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@apollo/react-hooks": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-hooks/-/react-hooks-3.1.5.tgz",
-      "integrity": "sha512-y0CJ393DLxIIkksRup4nt+vSjxalbZBXnnXxYbviq/woj+zKa431zy0yT4LqyRKpFy9ahMIwxBnBwfwIoupqLQ==",
-      "requires": {
-        "@apollo/react-common": "^3.1.4",
-        "@wry/equality": "^0.1.9",
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@apollo/react-ssr": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-ssr/-/react-ssr-3.1.5.tgz",
-      "integrity": "sha512-wuLPkKlctNn3u8EU8rlECyktpOUCeekFfb0KhIKknpGY6Lza2Qu0bThx7D9MIbVEzhKadNNrzLcpk0Y8/5UuWg==",
-      "requires": {
-        "@apollo/react-common": "^3.1.4",
-        "@apollo/react-hooks": "^3.1.5",
-        "tslib": "^1.10.0"
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.7.0",
+        "tslib": "^1.10.0",
+        "zen-observable": "^0.8.14"
       },
       "dependencies": {
         "tslib": {
@@ -23981,6 +23728,12 @@
         "minimist": "^1.2.0"
       }
     },
+    "@graphql-typed-document-node/core": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.0.tgz",
+      "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==",
+      "requires": {}
+    },
     "@hapi/accept": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.1.tgz",
@@ -25435,20 +25188,48 @@
       }
     },
     "@wry/context": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.4.4.tgz",
-      "integrity": "sha512-LrKVLove/zw6h2Md/KZyWxIkFM6AoyKp71OqpH9Hiip1csjPVoD3tPxlbQUNxEnHENks3UGgNpSBCAfq9KWuag==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.0.tgz",
+      "integrity": "sha512-sAgendOXR8dM7stJw3FusRxFHF/ZinU0lffsA2YTyyIOfic86JX02qlPqPVqJNZJPAxFt+2EE8bvq6ZlS0Kf+Q==",
       "requires": {
-        "@types/node": ">=6",
-        "tslib": "^1.9.3"
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
       }
     },
     "@wry/equality": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.9.tgz",
-      "integrity": "sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.1.tgz",
+      "integrity": "sha512-FZKbdpbcVcbDxQrKcaBClNsQaMg9nof1RKM7mReJe5DKUzM5u8S7T+PqwNqvib5O2j2xxF1R4p5O3+b6baTrbw==",
       "requires": {
-        "tslib": "^1.9.3"
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@wry/trie": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.0.tgz",
+      "integrity": "sha512-Yw1akIogPhAT6XPYsRHlZZIS0tIGmAl9EYXHi2scf7LPKKqdqmow/Hu4kEqP2cJR3EjaU/9L0ZlAjFf3hFxmug==",
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
       }
     },
     "@xtuc/ieee754": {
@@ -25669,17 +25450,6 @@
             "es-abstract": "^1.17.5"
           }
         },
-        "prop-types": {
-          "version": "15.7.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "object-assign": "^4.1.1",
-            "react-is": "^16.8.1"
-          }
-        },
         "react-is": {
           "version": "16.13.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -25824,145 +25594,6 @@
           "requires": {
             "remove-trailing-separator": "^1.0.1"
           }
-        }
-      }
-    },
-    "apollo-boost": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/apollo-boost/-/apollo-boost-0.4.9.tgz",
-      "integrity": "sha512-05y5BKcDaa8w47f8d81UVwKqrAjn8uKLv6QM9fNdldoNzQ+rnOHgFlnrySUZRz9QIT3vPftQkEz2UEASp1Mi5g==",
-      "requires": {
-        "apollo-cache": "^1.3.5",
-        "apollo-cache-inmemory": "^1.6.6",
-        "apollo-client": "^2.6.10",
-        "apollo-link": "^1.0.6",
-        "apollo-link-error": "^1.0.3",
-        "apollo-link-http": "^1.3.1",
-        "graphql-tag": "^2.4.2",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "apollo-cache": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.5.tgz",
-      "integrity": "sha512-1XoDy8kJnyWY/i/+gLTEbYLnoiVtS8y7ikBr/IfmML4Qb+CM7dEEbIUOjnY716WqmZ/UpXIxTfJsY7rMcqiCXA==",
-      "requires": {
-        "apollo-utilities": "^1.3.4",
-        "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "apollo-cache-inmemory": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.6.tgz",
-      "integrity": "sha512-L8pToTW/+Xru2FFAhkZ1OA9q4V4nuvfoPecBM34DecAugUZEBhI2Hmpgnzq2hTKZ60LAMrlqiASm0aqAY6F8/A==",
-      "requires": {
-        "apollo-cache": "^1.3.5",
-        "apollo-utilities": "^1.3.4",
-        "optimism": "^0.10.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "apollo-client": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.10.tgz",
-      "integrity": "sha512-jiPlMTN6/5CjZpJOkGeUV0mb4zxx33uXWdj/xQCfAMkuNAC3HN7CvYDyMHHEzmcQ5GV12LszWoQ/VlxET24CtA==",
-      "requires": {
-        "@types/zen-observable": "^0.8.0",
-        "apollo-cache": "1.3.5",
-        "apollo-link": "^1.0.0",
-        "apollo-utilities": "1.3.4",
-        "symbol-observable": "^1.0.2",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0",
-        "zen-observable": "^0.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "apollo-link": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
-      "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
-      "requires": {
-        "apollo-utilities": "^1.3.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3",
-        "zen-observable-ts": "^0.8.21"
-      }
-    },
-    "apollo-link-error": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/apollo-link-error/-/apollo-link-error-1.1.13.tgz",
-      "integrity": "sha512-jAZOOahJU6bwSqb2ZyskEK1XdgUY9nkmeclCrW7Gddh1uasHVqmoYc4CKdb0/H0Y1J9lvaXKle2Wsw/Zx1AyUg==",
-      "requires": {
-        "apollo-link": "^1.2.14",
-        "apollo-link-http-common": "^0.2.16",
-        "tslib": "^1.9.3"
-      }
-    },
-    "apollo-link-http": {
-      "version": "1.5.17",
-      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.17.tgz",
-      "integrity": "sha512-uWcqAotbwDEU/9+Dm9e1/clO7hTB2kQ/94JYcGouBVLjoKmTeJTUPQKcJGpPwUjZcSqgYicbFqQSoJIW0yrFvg==",
-      "requires": {
-        "apollo-link": "^1.2.14",
-        "apollo-link-http-common": "^0.2.16",
-        "tslib": "^1.9.3"
-      }
-    },
-    "apollo-link-http-common": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.16.tgz",
-      "integrity": "sha512-2tIhOIrnaF4UbQHf7kjeQA/EmSorB7+HyJIIrUjJOKBgnXwuexi8aMecRlqTIDWcyVXCeqLhUnztMa6bOH/jTg==",
-      "requires": {
-        "apollo-link": "^1.2.14",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3"
-      }
-    },
-    "apollo-utilities": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.4.tgz",
-      "integrity": "sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==",
-      "requires": {
-        "@wry/equality": "^0.1.2",
-        "fast-json-stable-stringify": "^2.0.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -28644,17 +28275,6 @@
         "semver": "^5.7.0"
       },
       "dependencies": {
-        "prop-types": {
-          "version": "15.7.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "object-assign": "^4.1.1",
-            "react-is": "^16.8.1"
-          }
-        },
         "react-is": {
           "version": "16.13.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -28677,17 +28297,6 @@
         "semver": "^5.7.1"
       },
       "dependencies": {
-        "prop-types": {
-          "version": "15.7.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "object-assign": "^4.1.1",
-            "react-is": "^16.8.1"
-          }
-        },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -29626,9 +29235,19 @@
       }
     },
     "graphql-tag": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.11.0.tgz",
-      "integrity": "sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA=="
+      "version": "2.12.5",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.5.tgz",
+      "integrity": "sha512-5xNhP4063d16Pz3HBtKprutsPrmHZi5IdUGOWRxA2B6VF7BIRGOHZ5WQvDmJXZuPcBg7rYwaFxvQYjqkSdR3TQ==",
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
     },
     "growly": {
       "version": "1.3.0",
@@ -33853,16 +33472,6 @@
           "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
           "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ=="
         },
-        "prop-types": {
-          "version": "15.7.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "object-assign": "^4.1.1",
-            "react-is": "^16.8.1"
-          }
-        },
         "react-is": {
           "version": "16.13.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -34641,11 +34250,12 @@
       "dev": true
     },
     "optimism": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.10.3.tgz",
-      "integrity": "sha512-9A5pqGoQk49H6Vhjb9kPgAeeECfUDF6aIICbMDL23kDLStBn1MWk3YvcZ4xWF9CsSf6XEgvRLkXy4xof/56vVw==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
+      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
       "requires": {
-        "@wry/context": "^0.4.0"
+        "@wry/context": "^0.6.0",
+        "@wry/trie": "^0.3.0"
       }
     },
     "optionator": {
@@ -35190,12 +34800,13 @@
       }
     },
     "prop-types": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
       "requires": {
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
       }
     },
     "prop-types-exact": {
@@ -35405,18 +35016,6 @@
       "resolved": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.6.2.tgz",
       "integrity": "sha1-wStu/cIkfBDae4dw0YUICnsEcVY=",
       "dev": true
-    },
-    "react-apollo": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/react-apollo/-/react-apollo-3.1.5.tgz",
-      "integrity": "sha512-xOxMqxORps+WHrUYbjVHPliviomefOpu5Sh35oO3osuOyPTxvrljdfTLGCggMhcXBsDljtS5Oy4g+ijWg3D4JQ==",
-      "requires": {
-        "@apollo/react-common": "^3.1.4",
-        "@apollo/react-components": "^3.1.5",
-        "@apollo/react-hoc": "^3.1.5",
-        "@apollo/react-hooks": "^3.1.5",
-        "@apollo/react-ssr": "^3.1.5"
-      }
     },
     "react-dom": {
       "version": "16.14.0",
@@ -37251,9 +36850,9 @@
       }
     },
     "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ=="
     },
     "symbol-tree": {
       "version": "3.2.4",
@@ -37635,11 +37234,18 @@
       "dev": true
     },
     "ts-invariant": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
-      "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.7.5.tgz",
+      "integrity": "sha512-qfVyqTYWEqADMtncLqwpUdMjMSXnsqOeqGtj1LeJNFDjz8oqZ1YxLEp29YCOq65z0LgEiERqQ8ThVjnfibJNpg==",
       "requires": {
-        "tslib": "^1.9.3"
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
       }
     },
     "ts-pnp": {
@@ -38643,15 +38249,6 @@
       "version": "0.8.15",
       "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
       "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
-    },
-    "zen-observable-ts": {
-      "version": "0.8.21",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
-      "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
-      "requires": {
-        "tslib": "^1.9.3",
-        "zen-observable": "^0.8.0"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "url": "https://github.com/shopify/shopify-app-node/issues"
   },
   "dependencies": {
+    "@apollo/client": "^3.3.20",
     "@babel/core": "7.12.10",
     "@babel/polyfill": "^7.6.0",
     "@babel/preset-env": "^7.12.11",
@@ -26,7 +27,6 @@
     "@shopify/app-bridge-utils": "^2.0.2",
     "@shopify/koa-shopify-auth": "^4.1.2",
     "@shopify/polaris": "^6.2.0",
-    "apollo-boost": "^0.4.9",
     "cross-env": "^7.0.3",
     "dotenv": "^8.2.0",
     "graphql": "^14.5.8",
@@ -38,7 +38,6 @@
     "next-env": "^1.1.0",
     "node-fetch": "^2.6.1",
     "react": "^16.10.1",
-    "react-apollo": "^3.1.3",
     "react-dom": "^16.10.1",
     "webpack": "^4.44.1"
   },

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,4 @@
-import ApolloClient from "apollo-boost";
-import { ApolloProvider } from "react-apollo";
+import { ApolloClient, ApolloProvider, InMemoryCache, createHttpLink } from '@apollo/client';
 import App from "next/app";
 import { AppProvider } from "@shopify/polaris";
 import { Provider, useAppBridge } from "@shopify/app-bridge-react";
@@ -34,11 +33,16 @@ function MyProvider(props) {
   const app = useAppBridge();
 
   const client = new ApolloClient({
-    fetch: userLoggedInFetch(app),
-    fetchOptions: {
-      credentials: "include",
-    },
+    cache: new InMemoryCache(),
+    link: createHttpLink({
+      credentials: 'include',
+      headers: {
+        "Content-Type": "application/graphql"
+      },
+      fetch: userLoggedInFetch(app)
+    })
   });
+
 
   const Component = props.Component;
 


### PR DESCRIPTION


<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

 `react-apollo` and `apollo-boost` are no longer maintained, the new `@apollo/client` library contains the functionality of both packages and is actively developed.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR updates the dependencies from  `react-apollo` and `apollo-boost` to `@apollo/client` and also contains relevant changes in ApolloClient object within the provider component. 

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
