### PR TITLE
Fix the CLI command for node app

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Boilerplate to create an embedded Shopify app made with Node, [Next.js](https://
 Using the [Shopify-App-CLI](https://github.com/Shopify/shopify-app-cli) run:
 
 ```sh
-~/ $ shopify create project APP_NAME
+~/ $ shopify node create -n APP_NAME
 ```
 
 Or, fork and clone repo


### PR DESCRIPTION
### WHY are these changes introduced?
The current shopify cli command doesn't work anymore.

### WHAT is this pull request doing?
For updating the CLI command with that works with the latest CLI