### PR TITLE
Bump koa-shopify-auth to v4.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4471,10 +4471,9 @@
       }
     },
     "node_modules/@shopify/koa-shopify-auth": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@shopify/koa-shopify-auth/-/koa-shopify-auth-4.1.2.tgz",
-      "integrity": "sha512-lKr7L6mgSvYg5B90SZYTznvLKKeqdxW9I83g5rM6N5t++b0l627ecqVcjdjPcSeX0PbofXsXRyCHdgnizzi8vw==",
-      "license": "MIT",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@shopify/koa-shopify-auth/-/koa-shopify-auth-4.1.4.tgz",
+      "integrity": "sha512-IcTnJTWewr60lRU04jOgtDm/KeRMi2PKHqRAuS3wjru9GRMHAxJhmEqPoEREWRPOxf8SnOPS4nyq5VsVOHoeqg==",
       "dependencies": {
         "@shopify/network": "^1.5.0",
         "@shopify/shopify-api": "^1.2.1",
@@ -24933,9 +24932,9 @@
       }
     },
     "@shopify/koa-shopify-auth": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@shopify/koa-shopify-auth/-/koa-shopify-auth-4.1.2.tgz",
-      "integrity": "sha512-lKr7L6mgSvYg5B90SZYTznvLKKeqdxW9I83g5rM6N5t++b0l627ecqVcjdjPcSeX0PbofXsXRyCHdgnizzi8vw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@shopify/koa-shopify-auth/-/koa-shopify-auth-4.1.4.tgz",
+      "integrity": "sha512-IcTnJTWewr60lRU04jOgtDm/KeRMi2PKHqRAuS3wjru9GRMHAxJhmEqPoEREWRPOxf8SnOPS4nyq5VsVOHoeqg==",
       "requires": {
         "@shopify/network": "^1.5.0",
         "@shopify/shopify-api": "^1.2.1",


### PR DESCRIPTION
This PR bumps the `koa-shopify-auth` package to its latest version.