### PR TITLE
Fix HOST environment variable parser (#644)

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -19,7 +19,7 @@ Shopify.Context.initialize({
   API_KEY: process.env.SHOPIFY_API_KEY,
   API_SECRET_KEY: process.env.SHOPIFY_API_SECRET,
   SCOPES: process.env.SCOPES.split(","),
-  HOST_NAME: process.env.HOST.replace(/https:\/\//, ""),
+  HOST_NAME: process.env.HOST.replace(/https:\/\/|\/$/g, ""),
   API_VERSION: ApiVersion.October20,
   IS_EMBEDDED_APP: true,
   // This should be replaced with your preferred storage strategy


### PR DESCRIPTION
### WHY are these changes introduced?
Fixes #644 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
This change allows for both patterns with a trailing slash and patterns without a trailing slash.
An example is shown below.
```
$ node --version
v16.5.0
$node
> "https://sampleapp.herokuapp.com/".replace(/https:\/\/|\/$/g, "")
'sampleapp.herokuapp.com'
> "https://sampleapp.herokuapp.com".replace(/https:\/\/|\/$/g, "")
'sampleapp.herokuapp.com'
```