### PR TITLE
fix for cli command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Boilerplate to create an embedded Shopify app made with Node, [Next.js](https://
 Using the [Shopify CLI](https://github.com/Shopify/shopify-cli) run:
 
 ```sh
-~/ $ shopify node create -n APP_NAME
+~/ $ shopify app create node
 ```
 
 Or, fork and clone repo


### PR DESCRIPTION
When I attempted to run the previous command on Shopify CLI 2.7.2, I was getting an error:

`shopify node was not found`

This PR updates the command to trigger the app create wizard.

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
