### PR TITLE
[SAMPLE_APP_UPDATES] [Feature] Added rate limiting on Apollo Client

### DIFF
--- a/client/components/App.js
+++ b/client/components/App.js
@@ -2,6 +2,7 @@ import React from "react";
 import {
   ApolloClient,
   ApolloProvider,
+  ApolloLink,
   InMemoryCache,
   HttpLink,
 } from "@apollo/client";
@@ -17,6 +18,8 @@ import "@shopify/polaris/build/esm/styles.css";
 
 import ProductsPage from "./ProductsPage";
 import PageLayout from "./PageLayout";
+
+import rateLimit from "../rateLimit";
 
 function userLoggedInFetch(app) {
   const fetchFunction = authenticatedFetch(app);
@@ -39,16 +42,19 @@ function userLoggedInFetch(app) {
     return response;
   };
 }
-
 const MyProvider = ({ children }) => {
   const app = useAppBridge();
 
+  const http = new HttpLink({
+    credentials: "include",
+    fetch: userLoggedInFetch(app),
+  });
+
+  const link = new ApolloLink.from([rateLimit, http]);
+
   const client = new ApolloClient({
     cache: new InMemoryCache(),
-    link: new HttpLink({
-      credentials: "include",
-      fetch: userLoggedInFetch(app),
-    }),
+    link,
   });
 
   return <ApolloProvider client={client}>{children}</ApolloProvider>;

--- a/client/rateLimit.js
+++ b/client/rateLimit.js
@@ -1,0 +1,83 @@
+import { onError } from "@apollo/client/link/error";
+import Observable from "zen-observable";
+
+function isThrottledError(error) {
+  return error.extensions.code === "THROTTLED";
+}
+
+function exceedsMaximumCost(cost) {
+  const {
+    requestedQueryCost,
+    actualQueryCost,
+    throttleStatus: { maximumAvailable },
+  } = cost;
+  const requested = actualQueryCost || requestedQueryCost;
+
+  return requested > maximumAvailable;
+}
+
+function calculateDelayCost(cost) {
+  const {
+    requestedQueryCost,
+    actualQueryCost,
+    throttleStatus: { currentlyAvailable, restoreRate },
+  } = cost;
+
+  const requested = actualQueryCost || requestedQueryCost;
+  const restoreAmount = Math.max(0, requested - currentlyAvailable);
+  const msToWait = Math.ceil(restoreAmount / restoreRate) * 1000;
+
+  return msToWait;
+}
+
+function delay(msToWait) {
+  return new Observable((observer) => {
+    let timer = setTimeout(() => {
+      observer.complete();
+    }, msToWait);
+
+    return () => clearTimeout(timer);
+  });
+}
+
+const rateLimit = onError(
+  ({ graphQLErrors, networkError, forward, operation, response }) => {
+    if (networkError) {
+      // A non 429 connection error.
+      // Fallback to ApolloClient's own error handler.
+      return;
+    }
+
+    if (!graphQLErrors) {
+      // An error we cannot respond to with rate limit handling. We require a specific error extension.
+      // Fallback to ApolloClient's own error handler.
+      return;
+    }
+
+    if (!graphQLErrors.some(isThrottledError)) {
+      // There was no throttling for this request.
+      // Fallback to ApolloClient's own error handler.
+      return;
+    }
+
+    const cost = response.extensions.cost;
+
+    if (!cost) {
+      // We require the cost extension to calculate the delay.
+      // Fallback to ApolloClient's own error handler.
+      return;
+    }
+
+    if (exceedsMaximumCost(cost)) {
+      // Your query costs more than the maximum allowed cost.
+      // Fallback to ApolloClient's own error handler.
+      return;
+    }
+    const msToWait = calculateDelayCost(cost);
+    operation.setContext({ retry: true, msToWait });
+
+    return delay(msToWait).concat(forward(operation));
+  }
+);
+
+export default rateLimit;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "shopify-app-node",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
@@ -31,7 +30,8 @@
         "react-dom": "^17.0.0",
         "style-loader": "^2.0.0",
         "webpack": "^4.44.1",
-        "webpack-cli": "^4.9.1"
+        "webpack-cli": "^4.9.1",
+        "zen-observable": "^0.8.15"
       },
       "devDependencies": {
         "@babel/plugin-transform-runtime": "^7.12.10",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "react-dom": "^17.0.0",
     "style-loader": "^2.0.0",
     "webpack": "^4.44.1",
-    "webpack-cli": "^4.9.1"
+    "webpack-cli": "^4.9.1",
+    "zen-observable": "^0.8.15"
   },
   "devDependencies": {
     "@babel/plugin-transform-runtime": "^7.12.10",


### PR DESCRIPTION
### WHY are these changes introduced?

To encourage responsible API usage. 

Currently there is no built in way to handle rate limiting. This causes unneeded stress on Shopify's api as well as dropped requests from the user's perspective.


### WHAT is this pull request doing?
This pull request is leveraging `@apollo/client` to wait for available points if applicable, dynamically responding to the shop's refresh rate, available bucket size, etc

### Introduced dependencies
[zen-observable](https://www.npmjs.com/package/zen-observable) 80kb, 6M weekly downloads, 0 dependencies. Very safe

### Test case
Below is a test case to run up the GQL limit in order to demonstrate the functionality. Feel free to insert your own.

```
const PRODUCTS_QUERY = gql`
  {
    products(first: 100) {
      edges {
        cursor
        node {
          id
          title
          onlineStoreUrl
        }
      }
    }
  }
`;
```

```js
  const [productQuery, productQueryState] = useLazyQuery(PRODUCTS_QUERY)

  useEffect(() => {
    for (let index = 0; index < 1000; index++) {
      console.log(index)
      productQuery({variables: {time: Date.now().toString()}});// adding date as unused var prevents request caching
    }
  },[])
```

