### PR TITLE
[SAMPLE_APP_UPDATES] Add node version constraints and update readme

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md)
 [![Build Status](https://travis-ci.com/Shopify/shopify-app-node.svg?branch=master)](https://travis-ci.com/Shopify/shopify-app-node)
 
+Recommended NodeJS version: v16
+
 Boilerplate to create an embedded Shopify app made with Node, [Polaris](https://github.com/Shopify/polaris-react), and [App Bridge React](https://shopify.dev/tools/app-bridge/react-components).
 
 ## Installation

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "shopify-app-node",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
@@ -43,6 +42,10 @@
         "prettier": "2.2.1",
         "regenerator-runtime": "^0.13.9",
         "webpack-dev-middleware": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=12.22.0 <=17.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@apollo/client": {

--- a/package.json
+++ b/package.json
@@ -63,5 +63,9 @@
     "*.{js,css,json,md}": [
       "prettier --write"
     ]
+  },
+  "engines": {
+    "npm": ">=7.0.0",
+    "node": ">=12.22.0 <=17.0.0"
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

There are a number of issues relating to node version errors so I believe it would be prudent to specify the required node version.

This should be non-breaking

### WHAT is this pull request doing?

Adding `engines` to package.json to be inline with package convention. node v17 has major breaking changes so I don't foresee this package being v17 compatible. I also limited the lower bound to v12 since that is the version required by React
