### PR TITLE
remove return response, graphql proxy returns response internally

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -59,8 +59,7 @@ export async function createServer(
 
   app.post("/graphql", async (req, res) => {
     try {
-      const response = await Shopify.Utils.graphqlProxy(req, res);
-      res.status(200).send(response.body);
+      await Shopify.Utils.graphqlProxy(req, res);
     } catch (error) {
       res.status(500).send(error.message);
     }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
We were getting the following error when trying to run the default app.
```
┃ Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
┃     at new NodeError (node:internal/errors:371:5)
┃     at ServerResponse.setHeader (node:_http_outgoing:576:11)
┃     at ServerResponse.header (/Users/meganmajewski/workspace/fullfillment-app/node_modules/express/lib/response.js:776:10)
┃     at ServerResponse.contentType (/Users/meganmajewski/workspace/fullfillment-app/node_modules/express/lib/response.js:604:15)
┃     at ServerResponse.send (/Users/meganmajewski/workspace/fullfillment-app/node_modules/express/lib/response.js:145:14)
┃     at file:///Users/meganmajewski/workspace/fullfillment-app/server/index.js:69:23

```

We determined this was because the graphqlProxy is already responding and ending the request internally. So we don't need to capture the response and end it again in the index file.


<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Removing the unnecessary response from the /graphql endpoint.
