### PR TITLE
fix CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14, "lts/*"]
+        node-version: [16, "lts/*"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,4 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn install
-      - run: yarn test
+      - run: NODE_ENV=test yarn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,5 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn install
+      - run: cp .env.test .env
       - run: NODE_ENV=test yarn test

--- a/.github/workflows/merge_patch_dependencies.yml
+++ b/.github/workflows/merge_patch_dependencies.yml
@@ -22,11 +22,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               event: 'APPROVE',
-            })
-
-            await github.rest.pulls.merge({
-              merge_method: "merge",
-              owner: repository.owner,
-              pull_number: pullRequest.number,
-              repo: repository.repo,
+              body: '@dependabot merge',
             })

--- a/server/__tests__/server.test.js
+++ b/server/__tests__/server.test.js
@@ -21,7 +21,7 @@ describe("shopify-app-node server", async () => {
       .set("Accept", "text/html");
 
     expect(response.status).toEqual(200);
-  });
+  }, 10000);
 
   test("redirects to auth if the app needs to be [re]installed", async () => {
     const response = await request(app)


### PR DESCRIPTION
Polaris v9 drops support for node v14 and it will soon be out the maintenance window anyway. Also tidying up the auto-merge patch workflow.