### PR TITLE
Forward all query parameters during app install flow

### DIFF
--- a/server/__tests__/server.test.js
+++ b/server/__tests__/server.test.js
@@ -81,12 +81,13 @@ describe("shopify-app-node server", async () => {
   });
 
   test("renders toplevel auth page", async () => {
+    const host = btoa("test-shop.myshopify.com/admin");
     const response = await request(app)
-      .get("/auth/toplevel?shop=test-shop")
+      .get(`/auth/toplevel?shop=test-shop&host=${host}`)
       .set("Accept", "text/html");
 
     expect(response.status).toEqual(200);
-    expect(response.text).toContain(`shopOrigin: 'test-shop'`);
+    expect(response.text).toContain(`host: '${host}'`);
   });
 
   test("goes through oauth flow if there is a top level cookie", async () => {

--- a/server/__tests__/server.test.js
+++ b/server/__tests__/server.test.js
@@ -82,6 +82,7 @@ describe("shopify-app-node server", async () => {
 
   test("renders toplevel auth page", async () => {
     const host = btoa("test-shop.myshopify.com/admin");
+
     const response = await request(app)
       .get(`/auth/toplevel?shop=test-shop&host=${host}`)
       .set("Accept", "text/html");

--- a/server/helpers/top-level-auth-redirect.js
+++ b/server/helpers/top-level-auth-redirect.js
@@ -1,4 +1,9 @@
-export default function topLevelAuthRedirect({ apiKey, hostName, host, shop }) {
+export default function topLevelAuthRedirect({
+  apiKey,
+  hostName,
+  host,
+  query,
+}) {
   return `<!DOCTYPE html>
 <html>
   <head>
@@ -6,7 +11,9 @@ export default function topLevelAuthRedirect({ apiKey, hostName, host, shop }) {
     <script>
       document.addEventListener('DOMContentLoaded', function () {
         if (window.top === window.self) {
-          window.location.href = '/auth?shop=${shop}';
+          window.location.href = '/auth?${new URLSearchParams(
+            query
+          ).toString()}';
         } else {
           var AppBridge = window['app-bridge'];
           var createApp = AppBridge.default;
@@ -21,7 +28,9 @@ export default function topLevelAuthRedirect({ apiKey, hostName, host, shop }) {
 
           redirect.dispatch(
             Redirect.Action.REMOTE,
-            'https://${hostName}/auth/toplevel?shop=${shop}',
+            'https://${hostName}/auth/toplevel?${new URLSearchParams(
+    query
+  ).toString()}',
           );
         }
       });

--- a/server/helpers/top-level-auth-redirect.js
+++ b/server/helpers/top-level-auth-redirect.js
@@ -4,6 +4,7 @@ export default function topLevelAuthRedirect({
   host,
   query,
 }) {
+  const serializedQuery = new URLSearchParams(query).toString();
   return `<!DOCTYPE html>
 <html>
   <head>
@@ -11,9 +12,7 @@ export default function topLevelAuthRedirect({
     <script>
       document.addEventListener('DOMContentLoaded', function () {
         if (window.top === window.self) {
-          window.location.href = '/auth?${new URLSearchParams(
-            query
-          ).toString()}';
+          window.location.href = '/auth?${serializedQuery}';
         } else {
           var AppBridge = window['app-bridge'];
           var createApp = AppBridge.default;
@@ -28,9 +27,7 @@ export default function topLevelAuthRedirect({
 
           redirect.dispatch(
             Redirect.Action.REMOTE,
-            'https://${hostName}/auth/toplevel?${new URLSearchParams(
-    query
-  ).toString()}',
+            'https://${hostName}/auth/toplevel?${serializedQuery}',
           );
         }
       });

--- a/server/helpers/top-level-auth-redirect.js
+++ b/server/helpers/top-level-auth-redirect.js
@@ -1,4 +1,4 @@
-export default function topLevelAuthRedirect({ apiKey, hostName, shop }) {
+export default function topLevelAuthRedirect({ apiKey, hostName, host, shop }) {
   return `<!DOCTYPE html>
 <html>
   <head>
@@ -14,7 +14,7 @@ export default function topLevelAuthRedirect({ apiKey, hostName, shop }) {
 
           const app = createApp({
             apiKey: '${apiKey}',
-            shopOrigin: '${shop}',
+            host: '${host}',
           });
 
           const redirect = Redirect.create(app);

--- a/server/index.js
+++ b/server/index.js
@@ -31,7 +31,7 @@ const ACTIVE_SHOPIFY_SHOPS = {};
 Shopify.Webhooks.Registry.addHandler("APP_UNINSTALLED", {
   path: "/webhooks",
   webhookHandler: async (topic, shop, body) => {
-    delete ACTIVE_SHOPIFY_SHOPS[shop]
+    delete ACTIVE_SHOPIFY_SHOPS[shop];
   },
 });
 
@@ -94,12 +94,12 @@ export async function createServer(
   });
 
   app.use("/*", (req, res, next) => {
-    const shop = req.query.shop;
+    const { shop, host } = req.query;
 
     // Detect whether we need to reinstall the app, any request from Shopify will
     // include a shop in the query parameters.
     if (app.get("active-shopify-shops")[shop] === undefined && shop) {
-      res.redirect(`/auth?shop=${shop}`);
+      res.redirect(`/auth?shop=${shop}&host=${host}`);
     } else {
       next();
     }

--- a/server/index.js
+++ b/server/index.js
@@ -94,7 +94,7 @@ export async function createServer(
   });
 
   app.use("/*", (req, res, next) => {
-    const { shop, host } = req.query;
+    const { shop } = req.query;
 
     // Detect whether we need to reinstall the app, any request from Shopify will
     // include a shop in the query parameters.

--- a/server/index.js
+++ b/server/index.js
@@ -99,7 +99,7 @@ export async function createServer(
     // Detect whether we need to reinstall the app, any request from Shopify will
     // include a shop in the query parameters.
     if (app.get("active-shopify-shops")[shop] === undefined && shop) {
-      res.redirect(`/auth?shop=${shop}&host=${host}`);
+      res.redirect(`/auth?${new URLSearchParams(req.query).toString()}`);
     } else {
       next();
     }

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -6,7 +6,7 @@ export default function applyAuthMiddleware(app) {
   app.get("/auth", async (req, res) => {
     if (!req.signedCookies[app.get("top-level-oauth-cookie")]) {
       return res.redirect(
-        `/auth/toplevel?shop=${req.query.shop}&host=${req.query.host}`
+        `/auth/toplevel?${new URLSearchParams(req.query).toString()}`
       );
     }
 
@@ -35,7 +35,7 @@ export default function applyAuthMiddleware(app) {
         apiKey: Shopify.Context.API_KEY,
         hostName: Shopify.Context.HOST_NAME,
         host: req.query.host,
-        shop: req.query.shop,
+        query: req.query,
       })
     );
   });

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -5,7 +5,9 @@ import topLevelAuthRedirect from "../helpers/top-level-auth-redirect.js";
 export default function applyAuthMiddleware(app) {
   app.get("/auth", async (req, res) => {
     if (!req.signedCookies[app.get("top-level-oauth-cookie")]) {
-      return res.redirect(`/auth/toplevel?shop=${req.query.shop}`);
+      return res.redirect(
+        `/auth/toplevel?shop=${req.query.shop}&host=${req.query.host}`
+      );
     }
 
     const redirectUrl = await Shopify.Auth.beginAuth(
@@ -32,6 +34,7 @@ export default function applyAuthMiddleware(app) {
       topLevelAuthRedirect({
         apiKey: Shopify.Context.API_KEY,
         hostName: Shopify.Context.HOST_NAME,
+        host: req.query.host,
         shop: req.query.shop,
       })
     );


### PR DESCRIPTION
The app was still using the old `shopOrigin` parameter for AppBridge. 

This PR switches out that old parameter for the new `host` one. Requires some additional passing around.