### PR TITLE
Add header sent check to webhook handler

### DIFF
--- a/server/__tests__/server.test.js
+++ b/server/__tests__/server.test.js
@@ -236,6 +236,21 @@ describe("shopify-app-node server", async () => {
       expect(response.status).toEqual(500);
       expect(response.text).toContain("test 500 response");
     });
+
+    test("does not write to response if webhook processing has already output headers", async () => {
+      const consoleSpy = vi.spyOn(console, "log");
+      process.mockImplementationOnce((request, response) => {
+        response.writeHead(400);
+        response.end();
+        throw new Error("something went wrong");
+      });
+
+      const response = await request(app).post("/webhooks");
+
+      expect(response.status).toEqual(400);
+      expect(consoleSpy).toHaveBeenCalled();
+      expect(consoleSpy.mock.lastCall[0]).toContain("something went wrong");
+    });
   });
 
   describe("graphql proxy", () => {

--- a/server/index.js
+++ b/server/index.js
@@ -55,7 +55,9 @@ export async function createServer(
       console.log(`Webhook processed, returned status code 200`);
     } catch (error) {
       console.log(`Failed to process webhook: ${error}`);
-      res.status(500).send(error.message);
+      if (!res.headersSent) {
+        res.status(500).send(error.message);
+      }
     }
   });
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #800

### WHAT is this pull request doing?

Adds a header sent check to the default webhook handler, to avoid crashes when Webhook processing has already sent a response.
